### PR TITLE
feat: remove husky and lint-staged

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,17 +43,6 @@
     "type": "git",
     "url": "https://github.com/micantoine/svelte-preprocess-cssmodules.git"
   },
-  "husky": {
-    "hooks": {
-      "pre-commit": "lint-staged"
-    }
-  },
-  "lint-staged": {
-    "*.{ts, js}": [
-      "eslint --fix",
-      "prettier --write"
-    ]
-  },
   "dependencies": {
     "acorn": "^8.5.0",
     "big.js": "^6.1.1",
@@ -69,9 +58,7 @@
     "eslint-config-airbnb-base": "^14.2.0",
     "eslint-config-prettier": "^6.15.0",
     "eslint-plugin-import": "^2.22.1",
-    "husky": "^4.3.0",
     "jest": "^26.0.1",
-    "lint-staged": "^10.5.1",
     "prettier": "^2.1.2",
     "svelte": "^3.22.3",
     "typescript": "^4.0.3"


### PR DESCRIPTION
This commit removes the husky and lint-staged packages from the project.
These packages were used for pre-commit linting and formatting checks.
However, they have been deemed unnecessary for this project at this time.
