### PR TITLE
refactor: remove .editorconfig file

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,7 +1,0 @@
-[*.{js,jsx,ts,tsx}]
-indent_style = space
-indent_size = 2
-end_of_line = lf
-trim_trailing_whitespace = true
-insert_final_newline = true
-max_line_length = 100


### PR DESCRIPTION
The .editorconfig file was removed from the project. This file was
previously used to enforce coding style rules such as indentation,
end of line character, trimming trailing whitespace, and maximum line
length. Its removal suggests that these rules will be enforced by
other means or are no longer necessary.
