### PR TITLE
feature/monorepo import package

### DIFF
--- a/example/rollup/package.json
+++ b/example/rollup/package.json
@@ -25,6 +25,7 @@
 		"svelte-as-markup-preprocessor": "^0.2.0",
 		"svelte-check": "^2.0.0",
 		"svelte-preprocess": "^4.0.0",
+		"svelte-preprocess-cssmodules": "workspace:*",
 		"tslib": "^2.0.0",
 		"typescript": "^4.0.0"
 	}

--- a/example/rollup/rollup.config.js
+++ b/example/rollup/rollup.config.js
@@ -6,7 +6,7 @@ import { terser } from 'rollup-plugin-terser';
 import { scss, typescript as typescriptSvelte } from 'svelte-preprocess';
 import typescript from '@rollup/plugin-typescript';
 import css from 'rollup-plugin-css-only';
-import { cssModules, linearPreprocess } from '../../dist/index';
+import { cssModules, linearPreprocess } from 'svelte-preprocess-cssmodules';
 
 const production = !process.env.ROLLUP_WATCH;
 

--- a/example/svelte-kit/package.json
+++ b/example/svelte-kit/package.json
@@ -9,6 +9,7 @@
 	},
 	"devDependencies": {
 		"@sveltejs/kit": "next",
-		"svelte": "^3.49.0"
+		"svelte": "^3.49.0",
+		"svelte-preprocess-cssmodules": "workspace:*"
 	}
 }

--- a/example/svelte-kit/svelte.config.js
+++ b/example/svelte-kit/svelte.config.js
@@ -1,4 +1,4 @@
-import cssModules from '../../dist/index.mjs';
+import { cssModules } from 'svelte-preprocess-cssmodules';
 
 /** @type {import('@sveltejs/kit').Config} */
 const config = {

--- a/package.json
+++ b/package.json
@@ -24,12 +24,10 @@
 	"exports": {
 		".": {
 			"import": "./dist/index.mjs",
-			"require": "./dist/index.js"
+			"require": "./dist/index.js",
+			"types": "./dist/index.d.ts"
 		}
 	},
-	"main": "./dist/index.js",
-	"module": "./dist/index.mjs",
-	"types": "./dist/index.d.ts",
 	"files": [
 		"dist/"
 	],

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -100,6 +100,9 @@ importers:
       svelte-preprocess:
         specifier: ^4.0.0
         version: 4.10.7(@babel/core@7.25.2)(postcss-load-config@3.1.4(postcss@8.4.40))(postcss@8.4.40)(sass@1.77.8)(svelte@3.59.2)(typescript@4.9.5)
+      svelte-preprocess-cssmodules:
+        specifier: workspace:*
+        version: link:../..
       tslib:
         specifier: ^2.0.0
         version: 2.6.3
@@ -115,6 +118,9 @@ importers:
       svelte:
         specifier: ^3.49.0
         version: 3.59.2
+      svelte-preprocess-cssmodules:
+        specifier: workspace:*
+        version: link:../..
 
 packages:
 


### PR DESCRIPTION
- **feat(package.json): add types to exports field**
- **feat: Use svelte-preprocess-cssmodules from workspace**


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced support for CSS modules in Svelte components, enhancing style modularization and encapsulation.
  
- **Bug Fixes**
  - Updated import paths in configuration files to standardize CSS preprocessing, improving maintainability.

- **Documentation**
  - Added TypeScript definitions to the package for better type support, benefiting TypeScript users.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->