### PR TITLE
feat: switch to svelte-parse-markup for parsing

### DIFF
--- a/package.json
+++ b/package.json
@@ -64,6 +64,7 @@
 		"scule": "^1.3.0",
 		"svelte": "5.0.0-next.208",
 		"svelte-eslint-parser": "^0.41.0",
+		"svelte-parse-markup": "^0.1.5",
 		"typescript": "^5.1.6",
 		"vitest": "^2.0.5",
 		"zimmerframe": "^1.1.2"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -54,6 +54,9 @@ importers:
       svelte-eslint-parser:
         specifier: ^0.41.0
         version: 0.41.0(svelte@5.0.0-next.208)
+      svelte-parse-markup:
+        specifier: ^0.1.5
+        version: 0.1.5(svelte@5.0.0-next.208)
       typescript:
         specifier: ^5.1.6
         version: 5.5.4
@@ -2658,6 +2661,11 @@ packages:
     engines: {node: ^12.20 || ^14.13.1 || >= 16}
     peerDependencies:
       svelte: ^3.19.0 || ^4.0.0
+
+  svelte-parse-markup@0.1.5:
+    resolution: {integrity: sha512-T6mqZrySltPCDwfKXWQ6zehipVLk4GWfH1zCMGgRtLlOIFPuw58ZxVYxVvotMJgJaurKi1i14viB2GIRKXeJTQ==}
+    peerDependencies:
+      svelte: ^3.0.0 || ^4.0.0 || ^5.0.0-next.1
 
   svelte-preprocess@5.1.4:
     resolution: {integrity: sha512-IvnbQ6D6Ao3Gg6ftiM5tdbR6aAETwjhHV+UKGf5bHGYR69RQvF1ho0JKPcbUON4vy4R7zom13jPjgdOWCQ5hDA==}
@@ -5720,6 +5728,10 @@ snapshots:
       svelte: 5.0.0-next.208
 
   svelte-hmr@0.16.0(svelte@5.0.0-next.208):
+    dependencies:
+      svelte: 5.0.0-next.208
+
+  svelte-parse-markup@0.1.5(svelte@5.0.0-next.208):
     dependencies:
       svelte: 5.0.0-next.208
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,5 @@
-import { parse, preprocess } from 'svelte/compiler';
+import { preprocess } from 'svelte/compiler';
+import { parse } from 'svelte-parse-markup';
 import type { Ast } from 'svelte/types/compiler/interfaces';
 import type { MarkupPreprocessor, PreprocessorGroup } from 'svelte/types/compiler/preprocess';
 import type { PluginOptions } from './types';

--- a/src/parsers/importDeclaration.ts
+++ b/src/parsers/importDeclaration.ts
@@ -1,7 +1,7 @@
 import path from 'node:path';
 import fs, { constants } from 'node:fs';
 import MagicString from 'magic-string';
-import { parse } from 'svelte/compiler';
+import { parse } from 'svelte-parse-markup';
 import { walk } from 'estree-walker';
 import type { TemplateNode } from 'svelte-eslint-parser/lib/parser/svelte-ast-types';
 import type Processor from '../processors/processor';


### PR DESCRIPTION
This commit switches the parsing library from 'svelte/compiler' to
'svelte-parse-markup'. This change is reflected in package.json,
pnpm-lock.yaml, and in the import statements in 'src/index.ts' and
'src/parsers/importDeclaration.ts'.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Added support for enhanced markup parsing in Svelte applications through integration with the `svelte-parse-markup` package.

- **Improvements**
	- Updated import statements to utilize the new `svelte-parse-markup` package, potentially improving parsing behavior and performance within the application.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->