### PR TITLE
feat: replace estree-walker with zimmerframe

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,8 +49,8 @@
 	"dependencies": {
 		"acorn": "^8.12.1",
 		"big.js": "^6.2.1",
-		"estree-walker": "^3.0.3",
-		"magic-string": "^0.25.7"
+		"magic-string": "^0.25.7",
+		"zimmerframe": "^1.1.2"
 	},
 	"devDependencies": {
 		"@antfu/ni": "^0.22.0",
@@ -66,7 +66,6 @@
 		"svelte-eslint-parser": "^0.41.0",
 		"svelte-parse-markup": "^0.1.5",
 		"typescript": "^5.1.6",
-		"vitest": "^2.0.5",
-		"zimmerframe": "^1.1.2"
+		"vitest": "^2.0.5"
 	}
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -14,12 +14,12 @@ importers:
       big.js:
         specifier: ^6.2.1
         version: 6.2.1
-      estree-walker:
-        specifier: ^3.0.3
-        version: 3.0.3
       magic-string:
         specifier: ^0.25.7
         version: 0.25.9
+      zimmerframe:
+        specifier: ^1.1.2
+        version: 1.1.2
     devDependencies:
       '@antfu/ni':
         specifier: ^0.22.0
@@ -63,9 +63,6 @@ importers:
       vitest:
         specifier: ^2.0.5
         version: 2.0.5(@types/node@22.1.0)(jsdom@16.7.0)(sass@1.77.8)(terser@5.31.3)
-      zimmerframe:
-        specifier: ^1.1.2
-        version: 1.1.2
 
   example/sveltekit:
     devDependencies:

--- a/src/parsers/importDeclaration.ts
+++ b/src/parsers/importDeclaration.ts
@@ -2,7 +2,7 @@ import path from 'node:path';
 import fs, { constants } from 'node:fs';
 import MagicString from 'magic-string';
 import { parse } from 'svelte-parse-markup';
-import { walk } from 'estree-walker';
+import { walk } from 'zimmerframe';
 import type { TemplateNode } from 'svelte-eslint-parser/lib/parser/svelte-ast-types';
 import type Processor from '../processors/processor';
 

--- a/src/parsers/template.ts
+++ b/src/parsers/template.ts
@@ -1,4 +1,4 @@
-import { walk } from 'estree-walker';
+import { walk } from 'zimmerframe';
 import type { Attribute, TemplateNode } from 'svelte-eslint-parser/lib/parser/svelte-ast-types';
 import type Processor from '../processors/processor';
 

--- a/src/processors/mixed.ts
+++ b/src/processors/mixed.ts
@@ -1,4 +1,4 @@
-import { walk } from 'estree-walker';
+import { walk } from 'zimmerframe';
 import type { AstLegacy, TemplateNode } from 'svelte-eslint-parser/lib/parser/svelte-ast-types';
 import type { PluginOptions } from '../types';
 import Processor from './processor';

--- a/src/processors/native.ts
+++ b/src/processors/native.ts
@@ -1,4 +1,4 @@
-import { walk } from 'estree-walker';
+import { walk } from 'zimmerframe';
 import type { AstLegacy, TemplateNode } from 'svelte-eslint-parser/lib/parser/svelte-ast-types';
 import type { PluginOptions } from '../types';
 import Processor from './processor';


### PR DESCRIPTION
This commit replaces the estree-walker package with zimmerframe in
various files. The zimmerframe package is now also added as a
dependency in package.json, while estree-walker is removed. The
pnpm-lock.yaml file is updated accordingly.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced the `zimmerframe` dependency, enhancing the application's capability to process abstract syntax trees (ASTs).
  
- **Bug Fixes**
	- Removed the outdated `estree-walker` dependency, streamlining the dependency management and potentially improving performance.

- **Refactor**
	- Updated import statements across several modules to utilize the new `zimmerframe` dependency for AST manipulation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->